### PR TITLE
Styling bug fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -109,7 +109,7 @@ onUnmounted(() => {
       <SectionHeader :title="'Accounts'" :id="'accounts'" :hierarchy="2" />
       <ContactsList />
 
-      <SectionHeader :title="'Send Me A Message!'" :id="'message'" :hierarchy="2" />
+      <SectionHeader :title="'Send Me A Message!'" :id="'message'" :hierarchy="3" />
       <MessageBoard />
 
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,18 +90,13 @@ onUnmounted(() => {
       <SkillsList />
 
       <SectionHeader :title="'Academics and Awards'" :id="'academics'" :hierarchy="2" />
-      <table id="academics-list">
-        <tbody>
-          <tr v-for="row in Math.ceil(ACADEMICS.length / 2)" :key="row">
-            <td v-for="col in 2" :key="col">
-              <Card 
-                v-if="(row - 1) * 2 + (col - 1) < ACADEMICS.length"
-                v-bind="ACADEMICS[(row - 1) * 2 + (col - 1)]" 
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div id="academics-list">
+        <Card 
+          v-for="academic in ACADEMICS"
+          :key="academic.title"
+          v-bind="academic"
+        />
+      </div>
       
 
       <!-- CONTACT -->
@@ -147,20 +142,13 @@ onUnmounted(() => {
   min-height: 100vh;
 }
 #academics-list {
-  border-collapse: collapse;
-  text-align: left;
-  table-layout: fixed;
-  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
 }
-#academics-list td {
-  vertical-align: bottom;
-  height: 1px;
-  /* Kind of hacky, so that the Cards fill the entire table cell and look even */
-}
-#academics-list td > * {
+#academics-list > * {
   margin-bottom: 0;
-  height: calc(100% - 16px - 16px - 2px - 2px);
-  /* Offset for 16px top and bottom paddings, 2px top and bottom border (see Card.vue styling) */
+  background-color: #95fff2;
 }
 
 #background {

--- a/src/components/content/Card.vue
+++ b/src/components/content/Card.vue
@@ -87,6 +87,7 @@ const thumbnail_path = computed(() => {
 .title {
   font-size: 28px;
   font-weight: bolder;
+  text-align: left;
 }
 .subtitle {
   color: #7d8c79;
@@ -94,6 +95,7 @@ const thumbnail_path = computed(() => {
 .content {
   display: flex;
   flex-direction: column;
+  text-align: left;
 }
 .content-text {
   font-size: 18px;

--- a/src/components/content/MessageBoard.vue
+++ b/src/components/content/MessageBoard.vue
@@ -115,6 +115,9 @@ button {
 
   font-family: Freemono, monospace;
   font-size: 16px;
+
+  color: #0E6875;
+  font-weight: bold;
 }
 button:hover {
   cursor: pointer;

--- a/src/components/content/SectionHeader.vue
+++ b/src/components/content/SectionHeader.vue
@@ -25,7 +25,7 @@ const icon_path = computed(() => {
 <template>
 
   <div :id="`section-header-id-${props.id}`" :class="`section-header heirarchy-${props.hierarchy}`">
-    <span class="heirarchy-indicator">{{ '\u2217'.repeat(props.hierarchy) }}</span>
+    <span class="heirarchy-indicator">{{ '\u273B'.repeat(props.hierarchy) }}</span>
     <img v-if="props.icon && props.icon_pos === 'prepend'" :src="icon_path" :alt="props.icon" class="icon" />
     <span class="header-text">{{ props.title }}</span>
     <img v-if="props.icon && props.icon_pos === 'append'" :src="icon_path" :alt="props.icon" class="icon" />
@@ -64,7 +64,7 @@ const icon_path = computed(() => {
   top: 50%;
   left: -8px;
 
-  font-size: 40px;
+  font-size: 24px;
   font-weight: bold;
   text-align: center;
 }
@@ -95,7 +95,7 @@ const icon_path = computed(() => {
 
     margin-right: 8px;
 
-    font-size: 32px;
+    font-size: 16px;
   }
 }
 


### PR DESCRIPTION
Attempts to fix the following:

-Academics cards contents overflowing past background on mobile.
-Hierarchy indicators (asterisks) on headers isn't vertically centered like in desktop, changed to a different asterisk character
-Card text alignments changed from justified to left
-Fixed colors of message board buttons